### PR TITLE
add url-hash to secure url

### DIFF
--- a/Model/QrCodeRenderer.php
+++ b/Model/QrCodeRenderer.php
@@ -26,7 +26,8 @@ class QrCodeRenderer
     public function __construct(
         private readonly Reader $configReader,
         private readonly UrlInterface $url,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly UrlHasher $urlHasher
     ) {
     }
 
@@ -99,7 +100,7 @@ class QrCodeRenderer
     {
         $src = $this->configReader->isEpcQrCodeImageSrcBase64Encoded() ?
             $this->getBase64EncodedQrCode($order) :
-            $this->url->getBaseUrl() . sprintf('epc-qr-code/image/png/order_id/%s', $order->getId());
+            $this->url->getBaseUrl() . sprintf('epc-qr-code/image/png/order_id/%s/hash/%s', $order->getId(), $this->urlHasher->createHashForOrder($order));
 
         if ($src === null) {
             return null;

--- a/Model/UrlHasher.php
+++ b/Model/UrlHasher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchrammelCodes\EpcQrCode\Model;
+
+use Magento\Sales\Api\Data\OrderInterface;
+
+class UrlHasher
+{
+    public function createHashForOrder(OrderInterface $order): string
+    {
+        $hashData = implode('', [
+            $order->getIncrementId(),
+            $order->getCustomerEmail(),
+            $order->getCreatedAt(),
+        ]);
+
+        return hash('sha256', $hashData);
+    }
+}


### PR DESCRIPTION
it should be not possible to create QR Codes without a valid hash, because with this it is possible to

- test against Order-IDs
- expose payment amounts
- expose increment-IDs

so this PR adds a hash to the URL, which is based on some unique values of the order