### PR TITLE
Feature: Introduce migration timestamp flag

### DIFF
--- a/Controller/Image/Png.php
+++ b/Controller/Image/Png.php
@@ -52,7 +52,9 @@ class Png implements HttpGetActionInterface
             throw new NotFoundException(__('Order with ID %s not found', $orderId));
         }
 
-        if ($this->request->getParam('hash') !== $this->urlHasher->createHashForOrder($order)) {
+        if ($this->urlHasher->shouldVerifyHashForOrder($order) &&
+            $this->request->getParam('hash') !== $this->urlHasher->createHashForOrder($order)
+        ) {
             throw new NotFoundException(__('Invalid hash'));
         }
 

--- a/Model/UrlHasher.php
+++ b/Model/UrlHasher.php
@@ -4,10 +4,26 @@ declare(strict_types=1);
 
 namespace SchrammelCodes\EpcQrCode\Model;
 
+use Magento\Framework\FlagManager;
 use Magento\Sales\Api\Data\OrderInterface;
+use Psr\Log\LoggerInterface;
 
 class UrlHasher
 {
+    public const EPC_QR_CODE_V2_1_UPGRADE_TIMESTAMP_FLAG = 'epc_qr_code_v2_1_upgrade_timestamp';
+
+    public function __construct(
+        private readonly FlagManager $flagManager,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Creates a unique hash for the order
+     *
+     * @param OrderInterface $order
+     * @return string
+     */
     public function createHashForOrder(OrderInterface $order): string
     {
         $hashData = implode('', [
@@ -17,5 +33,35 @@ class UrlHasher
         ]);
 
         return hash('sha256', $hashData);
+    }
+
+    /**
+     * Check if the given order expects hash verification or not
+     *
+     * @param OrderInterface $order
+     * @return bool
+     */
+    public function shouldVerifyHashForOrder(OrderInterface $order): bool
+    {
+        $moduleUpgradeAt = $this->flagManager->getFlagData(self::EPC_QR_CODE_V2_1_UPGRADE_TIMESTAMP_FLAG);
+        $orderCreationTimestamp = strtotime($order->getCreatedAt());
+
+        // In case the migration timestamp is missing or timestamp parsing for order creation date fails, bypass the
+        // hash validation with according WARNING log.
+        if ($moduleUpgradeAt === null || $orderCreationTimestamp === false) {
+            $this->logger->warning(
+                '[EPC QR Code] Hash validation omitted.',
+                [
+                    'orderId' => $order->getId(),
+                    'reason' => $moduleUpgradeAt === null ?
+                        'Module upgrade timestamp missing' :
+                        'Order creation datetime to timestamp conversion error'
+                ],
+            );
+
+            return false;
+        }
+
+        return $orderCreationTimestamp > $moduleUpgradeAt;
     }
 }

--- a/Setup/Patch/Data/SetUpgradeTimestampFlag.php
+++ b/Setup/Patch/Data/SetUpgradeTimestampFlag.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchrammelCodes\EpcQrCode\Setup\Patch\Data;
+
+use Magento\Framework\FlagManager;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
+use SchrammelCodes\EpcQrCode\Model\UrlHasher;
+
+class SetUpgradeTimestampFlag implements DataPatchInterface, PatchRevertableInterface
+{
+    public function __construct(private readonly FlagManager $flagManager)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply()
+    {
+        $this->flagManager->saveFlag(UrlHasher::EPC_QR_CODE_V2_1_UPGRADE_TIMESTAMP_FLAG, time());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function revert()
+    {
+        $this->flagManager->deleteFlag(UrlHasher::EPC_QR_CODE_V2_1_UPGRADE_TIMESTAMP_FLAG);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
To allow migration from v1.x to v2.x introduce a migration timestamp in order to compare order creation date against. In case the requested order got created prior to migration, the hash check is omitted.