### PR TITLE
Fix for PHP 8.4, make nullable types explicit.

### DIFF
--- a/Model/Config/Backend/Iban.php
+++ b/Model/Config/Backend/Iban.php
@@ -25,8 +25,8 @@ class Iban extends Value
         Registry $registry,
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);


### PR DESCRIPTION
We're upgrading a project of a client of ours to Magento 2.4.9 with PHP 8.5 and when running `setup:di:compile` we got this error:

```
$ bin/magento setup:di:compile
Compilation was started.
Repositories code generation... 1/9 [===>------------------------]  11% < 1 ms 80.0 MiB
In ErrorHandler.php line 61:

  Deprecated Functionality: SchrammelCodes\EpcQrCode\Model\Config\Backend\Iban::__construct(): Implicitly marking parameter $resource as nullable is deprecated, the explicit nullable type must be used instead in vendor/schrammel-codes/magento2-epc-qr-code/Model/Config/Backend/Iban.php on line 28
```

This PR fixes this.

(I've updated my suggested code fixes using a force-push in git, and also the PR's description and title, because I overlooked something at first, it should be good now)